### PR TITLE
development

### DIFF
--- a/pymd/services/ui/main_window.py
+++ b/pymd/services/ui/main_window.py
@@ -166,7 +166,9 @@ class MainWindow(QMainWindow):
         self.act_list = QAction("List", self, triggered=lambda: self._prefix_line("- "))
         self.act_img = QAction("Image", self, triggered=lambda: self._select_image())
         self.act_link = QAction("Link", self, triggered=lambda: self._create_link())
-        self.act_table = QAction("Table", self, shortcut="Ctrl+Shift+T", triggered=self._insert_table)
+        self.act_table = QAction(
+            "Table", self, shortcut="Ctrl+Shift+T", triggered=self._insert_table
+        )
 
         # NEW: Find/Replace actions with standard shortcuts (portable)
         self.act_find = QAction("Find", self)

--- a/pymd/services/ui/table_dialog.py
+++ b/pymd/services/ui/table_dialog.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QTextCursor
 from PyQt6.QtWidgets import (
     QButtonGroup,
@@ -139,7 +138,7 @@ class TableDialog(QDialog):
 
         # Header row
         if include_header:
-            header_cells = [f"Column {i+1}" for i in range(cols)]
+            header_cells = [f"Column {i + 1}" for i in range(cols)]
             lines.append("| " + " | ".join(header_cells) + " |")
             # Separator row
             lines.append("| " + " | ".join([sep] * cols) + " |")

--- a/tests/test_table_dialog.py
+++ b/tests/test_table_dialog.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QTextEdit
 
 from pymd.services.ui.table_dialog import TableDialog
@@ -50,10 +49,7 @@ def test_generate_table_with_header_left_align(dialog: TableDialog):
     table = dialog._generate_table()
 
     expected = (
-        "| Column 1 | Column 2 | Column 3 |\n"
-        "| --- | --- | --- |\n"
-        "|   |   |   |\n"
-        "|   |   |   |"
+        "| Column 1 | Column 2 | Column 3 |\n| --- | --- | --- |\n|   |   |   |\n|   |   |   |"
     )
     assert table == expected
 
@@ -67,11 +63,7 @@ def test_generate_table_with_header_center_align(dialog: TableDialog):
 
     table = dialog._generate_table()
 
-    expected = (
-        "| Column 1 | Column 2 |\n"
-        "| :---: | :---: |\n"
-        "|   |   |"
-    )
+    expected = "| Column 1 | Column 2 |\n| :---: | :---: |\n|   |   |"
     assert table == expected
 
 
@@ -84,11 +76,7 @@ def test_generate_table_with_header_right_align(dialog: TableDialog):
 
     table = dialog._generate_table()
 
-    expected = (
-        "| Column 1 | Column 2 |\n"
-        "| ---: | ---: |\n"
-        "|   |   |"
-    )
+    expected = "| Column 1 | Column 2 |\n| ---: | ---: |\n|   |   |"
     assert table == expected
 
 
@@ -100,12 +88,7 @@ def test_generate_table_without_header(dialog: TableDialog):
 
     table = dialog._generate_table()
 
-    expected = (
-        "|   |   |\n"
-        "| --- | --- |\n"
-        "|   |   |\n"
-        "|   |   |"
-    )
+    expected = "|   |   |\n| --- | --- |\n|   |   |\n|   |   |"
     assert table == expected
 
 
@@ -117,10 +100,7 @@ def test_generate_table_minimum_size(dialog: TableDialog):
 
     table = dialog._generate_table()
 
-    expected = (
-        "| Column 1 |\n"
-        "| --- |"
-    )
+    expected = "| Column 1 |\n| --- |"
     assert table == expected
 
 
@@ -201,7 +181,9 @@ def test_insert_table_cursor_positioning_with_header(qapp, editor: QTextEdit, di
     assert "Column 1" in line or "Column 2" in line
 
 
-def test_insert_table_cursor_positioning_without_header(qapp, editor: QTextEdit, dialog: TableDialog):
+def test_insert_table_cursor_positioning_without_header(
+    qapp, editor: QTextEdit, dialog: TableDialog
+):
     """Test that cursor is positioned correctly after insertion without header."""
     dialog.rows_spin.setValue(2)
     dialog.cols_spin.setValue(2)


### PR DESCRIPTION
## Summary
This PR adds a table insertion dialog feature to PyMarkdownEditor with the following capabilities:

    Configurable number of rows and columns (1-50 rows, 1-20 columns)
    Optional header row with auto-generated column labels
    Column alignment options (left, center, right)
    Keyboard shortcut: Ctrl+Shift+T
    Smart cursor positioning after insertion


## Type of change
- [ x ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional changes)
- [ ] test (adds/changes tests only)
- [ ] chore (build/CI/dev tooling)

## Screenshots / Demos (UI changes)


## How to test
1. Run PyMarkdownEditor binary on desktop PC
2. Click the table button in the secondary toolbar
3. Select the number of rows and columns from the dialog and click the Insert Table button
4. Check that the table is inserted at the current line position
5. Change the cursor position on the newly inserted table (so that its on the same line) and then click the insert table again, select columns and rows and click Insert Table button. Verify that the table was inserted onto a new line and not the same lin

## Checklist
- [ ] I opened/linked an issue for non-trivial changes
- [ x ] Code follows project style (pre-commit ran locally or CI autofix is OK)
- [ x ] Tests added/updated (positive + negative paths)
- [ x ] `pytest` passes locally
- [ ] Docs updated (README/CHANGELOG) if user-visible impact
- [ ] Commits are **DCO signed** (`git commit -s`)
