### PR TITLE
ci: Add assets folder to package so that assets/splash.png will be available for the binary builds.

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -57,6 +57,7 @@ jobs:
             Linux)
               # Onefile CLI/GUI binary (no .app on Linux)
               pyinstaller -F -n PyMarkdownEditor \
+                --add-data "assets:assets" \
                 --hidden-import backports \
                 --hidden-import backports.tarfile \
                 --hidden-import markdown \
@@ -74,6 +75,7 @@ jobs:
             macOS)
               # Produce a .app bundle on macOS (no -F)
               pyinstaller -n PyMarkdownEditor --windowed \
+                --add-data "assets:assets" \
                 --hidden-import backports \
                 --hidden-import backports.tarfile \
                 --hidden-import markdown \


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? Link to issues. -->
Description

- Update pyinstaller.spec to include assets folder in the package for the splash screen image
- Update release-binaries.yml Github Actions Workflow to add `--add-data "assets:assets"`

Fixes #<issue-id> (if applicable)

## Type of change
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation only)
- [ ] refactor (no functional changes)
- [ ] test (adds/changes tests only)
- [ ] chore (build/CI/dev tooling)

## Screenshots / Demos (UI changes)
<!-- Attach images/GIFs if the UI changed. -->

## How to test
1. …
2. …

## Checklist
- [ ] I opened/linked an issue for non-trivial changes
- [x] Code follows project style (pre-commit ran locally or CI autofix is OK)
- [x] Tests added/updated (positive + negative paths)
- [x] `pytest` passes locally
- [ ] Docs updated (README/CHANGELOG) if user-visible impact
- [ ] Commits are **DCO signed** (`git commit -s`)
